### PR TITLE
JBTM-3482: Updating Jacoco to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <version.org.sonatype.plugins.nexus-staging-maven-plugin>1.6.6</version.org.sonatype.plugins.nexus-staging-maven-plugin>
         <version.checkstyle>8.5</version.checkstyle>
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
-        <version.org.jacoco>0.8.2</version.org.jacoco>
+        <version.org.jacoco>0.8.8</version.org.jacoco>
         <version.simple-jndi>0.11.4.1</version.simple-jndi>
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>


### PR DESCRIPTION
Updating Jacoco to its latest version so that it could work on JDK17